### PR TITLE
Build release card to announce releases

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -26,12 +26,8 @@ Vixen is open source software distributed **free of charge**.
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" height="auto" >}}
-{{% blocks/feature icon="fa-lightbulb" title="Vixen 3.9u3 Released!" %}}
-The Vixen team has released Vixen 3.9u3.
 
-Please follow this space for updates!
-{{% /blocks/feature %}}
-
+{{< blocks/feature-release icon="fa-lightbulb" >}}
 
 {{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/VixenLights/vixen" %}}
 We do a [Pull Request](https://github.com/VixenLights/vixen/pulls) contributions workflow on **GitHub**. New contributors are always welcome!

--- a/layouts/shortcodes/blocks/feature-release.html
+++ b/layouts/shortcodes/blocks/feature-release.html
@@ -1,0 +1,22 @@
+{{ $release := site.Data.release.latest }}
+
+{{ $icon := .Get "icon" | default "fa-lightbulb" -}}
+{{ $url_text := .Get "url_text" -}}
+
+<div class="col-lg-4 mb-5 mb-lg-0 text-center">
+<div class="mb-4 h1">
+  <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
+</div>
+<h4 class="h3">
+    Vixen {{ $release.name  }} Released!
+</h4>
+<div class="mb-0">
+    <p>Release Date: {{ (dateFormat ":date_long" (time $release.published_at) ) }}. </p>
+    <p>
+        <a href="/download/release-build/">Download 
+	    </a>
+    </p>
+</div>
+{{ with .Get "url" }}<p><a href="{{ . }}">{{ with $url_text }}{{ $url_text }}{{ else }}{{ T "ui_read_more" }}{{ end }} …</a></p>{{ end }}
+</div>
+


### PR DESCRIPTION
* Create a new shortcut block that can be used to announce releases on the front page. This uses the latest data block at build time to dynamically create the release version info.