### PR TITLE
Update workflow triggers

### DIFF
--- a/.github/workflows/docker-production.yml
+++ b/.github/workflows/docker-production.yml
@@ -2,12 +2,6 @@ name: Docker - Prod
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - '**/.gitignore'
-      - '**/README.md'
 
 jobs:
   docker-prod:

--- a/.github/workflows/docker-staging.yml
+++ b/.github/workflows/docker-staging.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - develop
+      - master
     paths-ignore:
       - '**/.gitignore'
       - '**/README.md'


### PR DESCRIPTION
Update workflow triggers to support both staging and production being built from a single branch.  Changes the push branch from develp to master for the stage workflow.  Removes the push trigger entirely on the prod workflow (production builds will only be triggered manually).