### PR TITLE
Revert "Update workflow triggers"

### DIFF
--- a/.github/workflows/docker-production.yml
+++ b/.github/workflows/docker-production.yml
@@ -2,6 +2,12 @@ name: Docker - Prod
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/.gitignore'
+      - '**/README.md'
 
 jobs:
   docker-prod:

--- a/.github/workflows/docker-staging.yml
+++ b/.github/workflows/docker-staging.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - develop
     paths-ignore:
       - '**/.gitignore'
       - '**/README.md'


### PR DESCRIPTION
This reverts commit b0e2d924e1cab53b4262e6e462fc25713ceb91c2.

After further discussion, leave automatic staging builds from develop and automatic production builds from master.  Allows for longer running updates to the site to be completed on the develop branch if needed while still allowing other changes (or a manual rebuild) of production from the master branch.