### PR TITLE
Disallow all bots from indexing old builds

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Disallow: {{ if ne hugo.Environment "production" }}/{{ end }}
+{{ if ne hugo.Environment "production" }}Disallow: /{{ end }}
+Disallow: /builds/


### PR DESCRIPTION
GPTBot (OpenAI) decided it was a good idea to download ALL of the old installers to the tune of many gigs of data.  No value in any of these old installers getting indexed by any bots.  Block them.