### PR TITLE
docs(sequencer): document cursor-follows-selection and clone-vertical-drag

### DIFF
--- a/content/en/docs/usage/sequencer/sequencer-basics/edit-functions.md
+++ b/content/en/docs/usage/sequencer/sequencer-basics/edit-functions.md
@@ -5,7 +5,7 @@ weight: 10
 description: This section covers the basic edit functions.
 ---
 
-### Overview
+## Overview
 
 Editing a sequence is one of the most important aspects of creating your light show. The sequencer is intended to facilitate rapid creation of content and also to feel at home with standard conventions you have used in other applications.
 
@@ -27,13 +27,24 @@ Clicking the timeline and dragging the mouse with the left mouse button held wil
 
 Additional capabilities for selection are provide by the Draw Mode. See the section on [Draw Modes]({{< ref draw-mode.md>}}) for further details.
 
+### Cursor Movement on Selection
+
+By default, selecting an effect moves the timeline cursor to that effect's start time, keeping the cursor in sync with whatever you're working on. This applies whether you click a single effect, multi-select a group, or extend a selection with Ctrl or Shift.
+
+* **Single effect** &mdash; Clicking an effect moves the cursor to its start time, even if it was already selected.
+* **Multiple effects selected at once** &mdash; The cursor moves to the earliest start time among the selected effects.
+* **Ctrl/Shift click** &mdash; The cursor follows the most recently clicked effect rather than jumping to the earliest one in the selection.
+* **Lasso selection** &mdash; The cursor doesn't move while you're dragging the selection box. Once you release the mouse, the cursor moves to the earliest start time among the selected effects.
+
+Right-clicking an effect to open its context menu does not move the cursor. Right-clicking empty space on the Timeline still places the cursor at that time, as before. This behavior was modified in Build 1450. If you'd rather the cursor not move automatically when you select effects, check **Edit -> Legacy Cursor / Active Row** to restore the previous behavior.
+
 ### Editing Effects
 
 Effects can be edited in many ways. Clicking on any effect will bring up it's settings in the Effect Editor. You settings can be changed and the effect will render the changes on the fly. If you have multiple effects of the same type selected, all their settings can be edited at the same time. There are also some basic settings that may be the same for multiple types of effects. These can be edited at the same time as well. The [Effects][3] section details the settings for each Effect.
 
 Effects can be resized by clicking on the start or the end and dragging them to the new length you desire. Multiple effects can be selected at the same time and resizing them works in unison. See [Snap Points][1] for more info on getting effects to align to specific things in the Timeline.
 
-Effects can also be dragged from one element to another by clicking on them and dragging while holding the mouse down. Multiple effects can be selected and dragged at the same time. By holding the Ctrl key down while dragging the effect(s) you can create a copy of them and drag the copy to the new location. Holding the Shift key down locks the dragged effects in the same vertical time so you can move them up or down to another element. See the [Timeline][2] section for more details.
+Effects can also be dragged from one element to another by clicking on them and dragging while holding the mouse down. Multiple effects can be selected and dragged at the same time. By holding the Ctrl key down while dragging the effect(s) you can create a copy of them and drag the copy to the new location. Holding the Shift key down locks the dragged effects in the same vertical time so you can move them up or down to another element. Holding Ctrl + Shift down while dragging combines both behaviors: the selected effects are cloned, and the clones can only be dragged up or down to another element, keeping the same start and end times as the effects they were cloned from. See the [Timeline][2] section for more details.
 
 Clicking on the left edge of an effect while holding down the Alt key and moving the mouse will cause the effect just left to adjoin with this effect. Continuing to move the mouse while the Alt key is depressed will jointly size both effects. Similarly, clicking on the right side of an effect while holding down the Alt key and moving the mouse right will adjoin the immediate right effect. Continuing to move the mouse while the Alt key is depressed will jointly size both effects. Holding the Alt and Shift keys down together will work similarly, but only Effects at at the same [Layer][4] will be affected.
 

--- a/content/en/docs/usage/sequencer/sequencer-basics/editor-shortcut-keys.html
+++ b/content/en/docs/usage/sequencer/sequencer-basics/editor-shortcut-keys.html
@@ -68,6 +68,15 @@ description: This section covers the shortcut keys used in the application.
 
   <tr>
     <td>
+      Duplicate Effect and drag clone vertically only (locked in time)
+    </td>
+    <td>
+      Ctrl + Shift + Left Mouse and drag
+    </td>
+  </tr>
+
+  <tr>
+    <td>
       Add Multiple Effects form
     </td>
     <td>

--- a/content/en/docs/usage/sequencer/sequencer-basics/timeline.md
+++ b/content/en/docs/usage/sequencer/sequencer-basics/timeline.md
@@ -5,13 +5,15 @@ weight: 25
 description: This section covers the Timeline features.
 ---
 
-### Overview
+## Overview
 
 The Timeline is the heart of the sequence editor. It is divided up from left to right in minutes and seconds. Top to bottom in rows are the [Elements][1] you have defined in the [Display Setup][2]. These should correspond to the props in your display and may have [Groups][1] of props that you have organized. Any groups can be expanded to reveal the sub elements or other groups. The Timeline can be zoomed in or out to show as much or little of the time the sequence covers. There are keyboard and mouse shortcuts to control the zoom and allow panning from left to right and up and down. See the [Editor Shortcuts][3] section for more details on these commands.
 
 ### Time Ruler
 
 The ruler along the top contains the hash marks for the time intervals. These will vary from minutes to seconds to milliseconds as you zoom in and out. You can also click here to place a caret as the starting place or drag and select a range for the sequence when playing. See [Playing Sequences][4] for more information on this feature. Marks can be added here to mark beats or other important parts of the sequence and can be used as alignment references. Hovering the mouse near the bottom of the ruler will transition the cursor to a horizontal bar that you can click and drag to resize the height of the ruler. The time numbers will scale in size relative to the height. Marks can be added via the ruler. See [Adding Marks][13].
+
+Selecting effects on the Timeline also moves this cursor automatically to keep it in sync with your selection. See [Cursor Movement on Selection][16] for details on this behavior and how to turn it off.
 
 ### Mark Bar
 
@@ -33,7 +35,7 @@ Rows can also be collapsed quickly by clicking the **View -> Collapse All Elemen
 
 Effects can be moved around on the timeline by simply clicking on them and dragging it to the desired location. The length can also be changed by dragging on the beginning or end of the effect. A tool tip will appear when resizing to show the start and duration of the effect. The same tool tip will appear when hovering over the effect. Multiple effects can be moved or resized at the same time by multi selecting them. This uses standard select means of Ctrl/Shift click as you would see in any modern windows app. Once you have multiples selected, they can be moved or resized as a group. See the section on [Alignment Helpers][8] and the [Draw Indicator][9] sections for further ways to manipulate effects in relation to each other.
 
-Effects can also be [Cut, Copied and Pasted][10] from one place to another. Normal paradigms apply for this mechanism. Another way to make a quick copy of an effect is to Ctrl click and then drag on the effect. This will clone the selected effect(s) and allow you to quickly drag a copy of it else where. Holding the Shift key while dragging the effect will hold it at the time so you can drag it to another element and not change its position in time.
+Effects can also be [Cut, Copied and Pasted][10] from one place to another. Normal paradigms apply for this mechanism. Another way to make a quick copy of an effect is to Ctrl click and then drag on the effect. This will clone the selected effect(s) and allow you to quickly drag a copy of it else where. Holding the Shift key while dragging the effect will hold it at the time so you can drag it to another element and not change its position in time. Holding Ctrl + Shift while dragging clones the selected effect(s) and locks the clones to the same start and end times, letting you drag the clones straight up or down to another element without changing their position in time.
 
 Clicking on the left edge of an effect while holding down the Alt key and moving the mouse will cause the effect just left to adjoin with this effect. Continuing to move the mouse while the Alt key is depressed will jointly size both effects. Similarly, clicking on the right side of an effect while holding down the Alt key and moving the mouse right will adjoin the immediate right effect. Continuing to move the mouse while the Alt key is depressed will jointly size both effects. Holding the Alt and Shift keys down together will work similarly, but only Effects at at the same [Layer][15] will be affected.
 
@@ -68,3 +70,4 @@ Many of the Timeline settings are saved with each sequence you edit. Thus when y
  [13]: {{< ref "marks#adding-marks">}}
  [14]: {{< ref "marks#editing-marks">}}
  [15]: {{< ref "layers">}}
+ [16]: {{< ref "edit-functions#cursor-movement-on-selection">}}


### PR DESCRIPTION
## Summary
- Document VIX-3936 (timeline cursor follows effect selection, with the new **Edit -> Legacy Cursor / Active Row** opt-out) in `edit-functions.md` and cross-reference it from `timeline.md`.
- Document VIX-3940 (`Ctrl + Shift + Drag` clones selected effects and drags the clones vertically only, locked in time) in `edit-functions.md`, `timeline.md`, and add the shortcut to `editor-shortcut-keys.html`.

## Test plan
- [x] `hugo --quiet` builds without errors
- [ ] Spot check rendered pages with `hugo server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)