### PR TITLE
ci: replace szenius/set-timezone action with native TZ env var

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,12 +17,9 @@ jobs:
   docker:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    env:
+      TZ: America/Chicago
     steps:
-      - name: setup timezone
-        uses: szenius/set-timezone@v2.0
-        with:
-          timezoneLinux: "America/Chicago"
-    
       - name: Checkout repo
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Drops a stale third-party action (Node 20 deprecation warnings) in favor of setting TZ directly on the job, which ubuntu-latest respects natively.