### PR TITLE
feat(analytics): instrument downloads, fix feedback event, add consent banner

### DIFF
--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -37,7 +37,7 @@
       noButton.disabled = true;
     };
     const sendFeedback = (value) => {
-      if (!gtag) { console.log('!gtag'); }
+      if (typeof gtag !== 'function') return;
       gtag('event', 'feedback', {
         'event_category': value?'page helpful':'page not helpful',
         'event_label': window.location.pathname,

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,18 @@
+<script>
+  document.addEventListener('click', (event) => {
+    const link = event.target.closest('a[data-download-type]');
+    if (!link) return;
+    if (typeof gtag !== 'function') return;
+
+    const url = new URL(link.href, window.location.href);
+    gtag('event', 'file_download', {
+      'file_name': url.pathname.split('/').pop(),
+      'link_url': link.href,
+      'link_domain': url.hostname,
+      'build_type': link.dataset.downloadType,
+      'bitness': link.dataset.bitness,
+      'version': link.dataset.version,
+      'page_path': window.location.pathname
+    });
+  });
+</script>

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -16,3 +16,42 @@
     });
   });
 </script>
+
+{{ if hugo.IsProduction -}}
+<div id="consent-banner" class="d-print-none" role="region" aria-label="Cookie consent"
+     style="display:none; position:fixed; bottom:0; left:0; right:0; z-index:1050; background:#212529; color:#fff; padding:1rem;">
+  <div class="container d-flex flex-wrap align-items-center justify-content-between gap-3">
+    <p class="mb-0 me-3">
+      We use Google Analytics to understand how the site is used. See our
+      <a href="{{ .Site.Params.privacy_policy }}" class="text-white text-decoration-underline">privacy policy</a>.
+    </p>
+    <div class="d-flex gap-2">
+      <button id="consent-decline" type="button" class="btn btn-outline-light btn-sm">Decline</button>
+      <button id="consent-accept" type="button" class="btn btn-primary btn-sm">Accept</button>
+    </div>
+  </div>
+</div>
+<script>
+  (function() {
+    const banner = document.getElementById('consent-banner');
+    if (!banner) return;
+
+    let stored;
+    try { stored = localStorage.getItem('consent-analytics'); } catch (e) {}
+    if (!stored) banner.style.display = 'block';
+
+    document.getElementById('consent-accept').addEventListener('click', () => {
+      try { localStorage.setItem('consent-analytics', 'granted'); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+      banner.style.display = 'none';
+    });
+
+    document.getElementById('consent-decline').addEventListener('click', () => {
+      try { localStorage.setItem('consent-analytics', 'denied'); } catch (e) {}
+      banner.style.display = 'none';
+    });
+  })();
+</script>
+{{ end -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,22 @@
+{{ if hugo.IsProduction -}}
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+
+  gtag('consent', 'default', {
+    'analytics_storage': 'denied',
+    'ad_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'wait_for_update': 500
+  });
+
+  (function() {
+    try {
+      if (localStorage.getItem('consent-analytics') === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+  })();
+</script>
+{{ end -}}

--- a/layouts/shortcodes/devbuild-first.html
+++ b/layouts/shortcodes/devbuild-first.html
@@ -1,4 +1,5 @@
 {{ range first 1 (where hugo.Data.release.all "prerelease" "eq" true) }}
+{{ $version := .name }}
 
 <div class="card mb-4 w-75">
     <div class="card-body">
@@ -8,18 +9,18 @@
             {{ range .assets }}
                 {{ if strings.HasSuffix .name "64bit.exe" }}
                     <p class="card-text">64 Bit Development Build</p>
-                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}">{{ .name }}</a></p>
+                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="development" data-bitness="64bit" data-version="{{ $version }}">{{ .name }}</a></p>
                 {{ end }}
             {{ end }}
             {{ range .assets }}
                 {{ if strings.HasSuffix .name "32bit.exe" }}
                     <p class="card-text">32 Bit Development Build</p>
-                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}">{{ .name }}</a></p>
+                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="development" data-bitness="32bit" data-version="{{ $version }}">{{ .name }}</a></p>
                 {{ end }}
             {{ end }}
         </ul>
     </div>
-    
+
 </div>
 
 {{ end }}

--- a/layouts/shortcodes/release-all.html
+++ b/layouts/shortcodes/release-all.html
@@ -1,4 +1,6 @@
 {{ range hugo.Data.release.all }}
+{{ $version := .name }}
+{{ $buildType := cond .prerelease "development" "production" }}
 <div class="card mb-4">
     <div class="card-body">
         <h5 class="card-title">Version: {{ .name }}</h5>
@@ -6,7 +8,8 @@
     </div>
     <ul class="list-group list-group-flush">
         {{ range .assets }}
-        <li class="list-group-item"><a href="{{ .browser_download_url }}">{{ .name }}</a></li>
+        {{ $bitness := cond (strings.HasSuffix .name "64bit.exe") "64bit" (cond (strings.HasSuffix .name "32bit.exe") "32bit" "") }}
+        <li class="list-group-item"><a href="{{ .browser_download_url }}" data-download-type="{{ $buildType }}" data-bitness="{{ $bitness }}" data-version="{{ $version }}">{{ .name }}</a></li>
         {{ end }}
     </ul>
 </div>

--- a/layouts/shortcodes/release-latest.html
+++ b/layouts/shortcodes/release-latest.html
@@ -6,13 +6,13 @@
         {{ range $release.assets }}
             {{ if strings.HasSuffix .name "64bit.exe" }}
                 <p class="card-text">64 bit Release Build</p>
-                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}">{{ .name }}</a></p>
+                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="production" data-bitness="64bit" data-version="{{ $release.name }}">{{ .name }}</a></p>
             {{ end }}
         {{ end }}
         {{ range $release.assets }}
             {{ if strings.HasSuffix .name "32bit.exe" }}
                 <p class="card-text">32 bit build for older computers. This will likely be phased out in 2023.</p>
-                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}">{{ .name }}</a></p>
+                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="production" data-bitness="32bit" data-version="{{ $release.name }}">{{ .name }}</a></p>
             {{ end }}
         {{ end }}
     </div>


### PR DESCRIPTION
## Summary
- Tag production/development download links with `build_type`, `bitness`, and `version` data attributes, and fire a GA4 `file_download` event on click — GA4's Enhanced Measurement doesn't auto-track `.exe` downloads or distinguish dev vs. production builds.
- Fix `feedback.html`'s gtag guard, which threw a `ReferenceError` instead of failing safe when `gtag` isn't loaded.
- Gate Google Analytics behind a lightweight consent banner using GA4 Consent Mode v2 (`analytics_storage` defaults to denied until accepted), gated on `hugo.IsProduction` to match where GA itself loads.

## Test plan
- [x] `hugo --environment production` builds cleanly; consent script + banner render, GA snippet present
- [x] `hugo --environment staging` builds cleanly; consent script + banner + GA snippet all absent (matches existing staging behavior — GA never loads there)
- [x] Verified download shortcode output includes correct `data-download-type`/`data-bitness`/`data-version` for release, dev-build, and legacy-build pages
- [ ] Manual click-through on a deployed environment to confirm `file_download` and `feedback` events land in GA4 Realtime with expected custom dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)