### PR TITLE
fix(analytics): open download links in a new tab to avoid lost GA4 beacons

### DIFF
--- a/layouts/shortcodes/devbuild-first.html
+++ b/layouts/shortcodes/devbuild-first.html
@@ -9,13 +9,13 @@
             {{ range .assets }}
                 {{ if strings.HasSuffix .name "64bit.exe" }}
                     <p class="card-text">64 Bit Development Build</p>
-                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="development" data-bitness="64bit" data-version="{{ $version }}">{{ .name }}</a></p>
+                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="development" data-bitness="64bit" data-version="{{ $version }}" target="_blank" rel="noopener">{{ .name }}</a></p>
                 {{ end }}
             {{ end }}
             {{ range .assets }}
                 {{ if strings.HasSuffix .name "32bit.exe" }}
                     <p class="card-text">32 Bit Development Build</p>
-                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="development" data-bitness="32bit" data-version="{{ $version }}">{{ .name }}</a></p>
+                    <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="development" data-bitness="32bit" data-version="{{ $version }}" target="_blank" rel="noopener">{{ .name }}</a></p>
                 {{ end }}
             {{ end }}
         </ul>

--- a/layouts/shortcodes/release-all.html
+++ b/layouts/shortcodes/release-all.html
@@ -9,7 +9,7 @@
     <ul class="list-group list-group-flush">
         {{ range .assets }}
         {{ $bitness := cond (strings.HasSuffix .name "64bit.exe") "64bit" (cond (strings.HasSuffix .name "32bit.exe") "32bit" "") }}
-        <li class="list-group-item"><a href="{{ .browser_download_url }}" data-download-type="{{ $buildType }}" data-bitness="{{ $bitness }}" data-version="{{ $version }}">{{ .name }}</a></li>
+        <li class="list-group-item"><a href="{{ .browser_download_url }}" data-download-type="{{ $buildType }}" data-bitness="{{ $bitness }}" data-version="{{ $version }}" target="_blank" rel="noopener">{{ .name }}</a></li>
         {{ end }}
     </ul>
 </div>

--- a/layouts/shortcodes/release-latest.html
+++ b/layouts/shortcodes/release-latest.html
@@ -6,13 +6,13 @@
         {{ range $release.assets }}
             {{ if strings.HasSuffix .name "64bit.exe" }}
                 <p class="card-text">64 bit Release Build</p>
-                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="production" data-bitness="64bit" data-version="{{ $release.name }}">{{ .name }}</a></p>
+                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="production" data-bitness="64bit" data-version="{{ $release.name }}" target="_blank" rel="noopener">{{ .name }}</a></p>
             {{ end }}
         {{ end }}
         {{ range $release.assets }}
             {{ if strings.HasSuffix .name "32bit.exe" }}
                 <p class="card-text">32 bit build for older computers. This will likely be phased out in 2023.</p>
-                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="production" data-bitness="32bit" data-version="{{ $release.name }}">{{ .name }}</a></p>
+                <p class="card-text"><a href="{{ .browser_download_url }}" aria-label="{{ .name }}" data-download-type="production" data-bitness="32bit" data-version="{{ $release.name }}" target="_blank" rel="noopener">{{ .name }}</a></p>
             {{ end }}
         {{ end }}
     </div>


### PR DESCRIPTION
## Summary
- Download links (dev build, latest release, all releases) navigated the current tab directly to github.com, which raced the async gtag `file_download` beacon and got the collect request canceled by the browser before it reached GA servers.
- Added `target="_blank" rel="noopener"` to the download links in `devbuild-first.html`, `release-all.html`, and `release-latest.html` so the current tab stays alive long enough for the analytics beacon to complete.

## Test plan
- [x] Built the site locally with `hugo --environment production` and confirmed `target="_blank" rel="noopener"` is present on rendered download links for both dev and release build pages.
- [ ] Verify in GA4 DebugView / Network tab that `file_download` collect requests no longer show as failed/canceled after deploy.